### PR TITLE
Repayment intdeductrebates and remove rebate ledger

### DIFF
--- a/app/Models/EndTransaction.php
+++ b/app/Models/EndTransaction.php
@@ -260,7 +260,7 @@ class EndTransaction extends Model
                         case 'Rebates':
 
                             if ($payment->rebates > 0 && $payment->rebates_approval_no) {
-                                $ledger[$key]['debit'] += $payment->rebates;
+                             //   $ledger[$key]['debit'] += $payment->rebates;
                             }
 
                             break;
@@ -271,7 +271,7 @@ class EndTransaction extends Model
                                 $r = $payment->rebates;
                             }
 
-                            $ledger[$key]['credit'] += ($payment->interest + $r);
+                            $ledger[$key]['credit'] += ($payment->interest);
                             break;
                         case 'Penalty Income':
 

--- a/app/Models/EndTransaction.php
+++ b/app/Models/EndTransaction.php
@@ -253,7 +253,7 @@ class EndTransaction extends Model
                         case 'Cash':
 
                             if (Str::contains(Str::lower($payment->payment_type), 'cash')) {
-                                $ledger[$key]['debit'] += $payment->amount_applied;
+                                $ledger[$key]['debit'] += ($payment->amount_applied - $payment->rebates);
                             }
 
                             break;
@@ -296,7 +296,7 @@ class EndTransaction extends Model
                         case 'Memo':
 
                             if (Str::contains(Str::lower($payment->payment_type), 'memo')) {
-                                $ledger[$key]['debit'] += $payment->amount_applied;
+                                $ledger[$key]['debit'] += ($payment->amount_applied - $payment->rebates);
                             }
 
                             break;

--- a/resources/js/ui/reports/repayment/Client.vue
+++ b/resources/js/ui/reports/repayment/Client.vue
@@ -338,7 +338,7 @@ export default {
 				result[8] += r.pdi;
 				result[9] += r.overpayment;
 				result[10] += r.total;
-				result[11] += r.interest / (1.12);
+				result[11] += (r.interest-r.rebates) / (1.12);
 				result[12] += r.pdi / (1.12);
 				result[13] += r.vat;
 			});

--- a/resources/js/ui/reports/repayment/Client.vue
+++ b/resources/js/ui/reports/repayment/Client.vue
@@ -67,7 +67,6 @@
 							<th>Int.</th>
 							<th>PD Int.</th>
 							<th>Over</th>
-							<th>Discount</th>
 							<th>Tot. Payment</th>
 							<th>VATable Int.</th>
 							<th>VATable PDI.</th>
@@ -84,10 +83,9 @@
 								<td>{{formatToCurrency(r.amortization_principal)}}</td>
 								<td>{{formatToCurrency(r.principal)}}</td>
 								<td>{{formatToCurrency(r.amortization_interest)}}</td>
-								<td>{{formatToCurrency(r.interest)}}</td>
+								<td>{{formatToCurrency(r.interest - r.rebates) }}</td>
 								<td>{{formatToCurrency(r.pdi)}}</td>
 								<td>{{formatToCurrency(r.overpayment)}}</td>
-								<td>{{formatToCurrency(r.rebates)}}</td>
 								<td>{{formatToCurrency(r.total)}}</td>
 								<td>{{formatToCurrency(r.net_interest/(1.12))}}</td>
 								<td>{{formatToCurrency(r.net_pdi /(1.12))}}</td>
@@ -331,19 +329,18 @@ export default {
 			return this.accountOfficers.filter(ao=>ao.status=='active'&&ao.branch_id==this.branch.branch_id);
 		},
 		total:function(){
-			var result = ['TOTAL','','','',0,0,0,0,0,0,0,0,0,0,0,''];
+			var result = ['TOTAL','','','',0,0,0,0,0,0,0,0,0,0,''];
 			this.reports.forEach(r => {
 				result[4] += r.amortization_principal;
 				result[5] += r.principal;
 				result[6] += r.amortization_interest;
-				result[7] += r.interest;
+				result[7] += r.interest-r.rebates;
 				result[8] += r.pdi;
 				result[9] += r.overpayment;
-				result[10] += r.rebates;
-				result[11] += r.total;
-				result[12] += r.net_interest / (1.12);
-				result[13] += r.net_pdi / (1.12);
-				result[14] += r.vat;
+				result[10] += r.total;
+				result[11] += r.interest / (1.12);
+				result[12] += r.pdi / (1.12);
+				result[13] += r.vat;
 			});
 			return result;
 		},


### PR DESCRIPTION
Updates:
1. remove discount column in summary of repayment
2. remove interest income rebate in the ledger
3. deduct rebate to interest income
4. added VAT PDI and VAT Interest 
   a. VATAble Int = total Interest / 1.12
   b. VATable PDI = total PDI / 1.12
5. Added borrower number column 
