### PR TITLE
Multiple Payments Fix

### DIFF
--- a/app/Models/Payment.php
+++ b/app/Models/Payment.php
@@ -331,10 +331,12 @@ class Payment extends Model
 
     public function getOngoingPayment($request = array())
     {
-        return Payment::where([
-            'loan_account_id' => $request['loan_account_id'],
-            'status' => 'open'
-        ])->get()->first();
+        return DB::transaction(function () use ($request) {
+            return Payment::where([
+                'loan_account_id' => $request['loan_account_id'], 
+                'status' => 'open'
+            ])->lockForUpdate()->first();
+        });
     }
 
     public function deleteMemoPaymentIfExists($loanAccount)


### PR DESCRIPTION
Created a lock that ensures only one request can check for pending payments at a time for the same loan account.